### PR TITLE
Update configurations for the Gradle Enterprise cache

### DIFF
--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -21,5 +21,8 @@
     <local>
       <enabled>true</enabled>
     </local>
+    <remote>
+      <enabled>false</enabled>
+    </remote>
   </buildCache>
 </gradleEnterprise>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -19,7 +19,7 @@
   </buildScan>
   <buildCache>
     <local>
-      <enabled>true</enabled>
+      <enabled>#{isFalse(env['JENKINS_URL'])}</enabled>
     </local>
     <remote>
       <enabled>false</enabled>


### PR DESCRIPTION
This PR makes two changes:

* Disables the remote cache
* Disables the local cache for CI builds